### PR TITLE
fix(book): 发送评论增加小说存在性校验，用户评论查询增强代码健壮性

### DIFF
--- a/src/main/java/io/github/xxyopen/novel/core/common/constant/ErrorCodeEnum.java
+++ b/src/main/java/io/github/xxyopen/novel/core/common/constant/ErrorCodeEnum.java
@@ -100,6 +100,11 @@ public enum ErrorCodeEnum {
     USER_COMMENTED("A2001", "用户已发表评论"),
 
     /**
+     * 小说不存在
+     */
+    BOOK_NOT_FOUND("A2002", "小说ID不存在"),
+
+    /**
      * 作家发布异常
      */
     AUTHOR_PUBLISH("A3000", "作家发布异常"),

--- a/src/main/java/io/github/xxyopen/novel/service/impl/BookServiceImpl.java
+++ b/src/main/java/io/github/xxyopen/novel/service/impl/BookServiceImpl.java
@@ -443,23 +443,28 @@ public class BookServiceImpl implements BookService {
             .orderByDesc(DatabaseConsts.CommonColumnEnum.UPDATE_TIME.getName());
         IPage<BookComment> bookCommentPage = bookCommentMapper.selectPage(page, queryWrapper);
         List<BookComment> comments = bookCommentPage.getRecords();
+        
+        List<UserCommentRespDto> commentRespDtoList = Collections.emptyList();
         if (!CollectionUtils.isEmpty(comments)) {
             List<Long> bookIds = comments.stream().map(BookComment::getBookId).toList();
             QueryWrapper<BookInfo> bookInfoQueryWrapper = new QueryWrapper<>();
             bookInfoQueryWrapper.in(DatabaseConsts.CommonColumnEnum.ID.getName(), bookIds);
             Map<Long, BookInfo> bookInfoMap = bookInfoMapper.selectList(bookInfoQueryWrapper).stream()
                 .collect(Collectors.toMap(BookInfo::getId, Function.identity()));
-            return RestResp.ok(PageRespDto.of(pageReqDto.getPageNum(), pageReqDto.getPageSize(), page.getTotal(),
-                comments.stream().map(v -> UserCommentRespDto.builder()
+            
+            commentRespDtoList = comments.stream().map(v -> {
+                BookInfo bookInfo = bookInfoMap.get(v.getBookId());
+                return UserCommentRespDto.builder()
                     .commentContent(v.getCommentContent())
-                    .commentBook(bookInfoMap.get(v.getBookId()).getBookName())
-                    .commentBookPic(bookInfoMap.get(v.getBookId()).getPicUrl())
+                    .commentBook(bookInfo != null ? bookInfo.getBookName() : null)
+                    .commentBookPic(bookInfo != null ? bookInfo.getPicUrl() : null)
                     .commentTime(v.getCreateTime())
-                    .build()).toList()));
-
+                    .build();
+            }).toList();
         }
-        return RestResp.ok(PageRespDto.of(pageReqDto.getPageNum(), pageReqDto.getPageSize(), page.getTotal(),
-            Collections.emptyList()));
+        
+        return RestResp.ok(PageRespDto.of(pageReqDto.getPageNum(), pageReqDto.getPageSize(), 
+            page.getTotal(), commentRespDtoList));
     }
 
     @Transactional(rollbackFor = Exception.class)

--- a/src/main/java/io/github/xxyopen/novel/service/impl/BookServiceImpl.java
+++ b/src/main/java/io/github/xxyopen/novel/service/impl/BookServiceImpl.java
@@ -230,6 +230,11 @@ public class BookServiceImpl implements BookService {
     @Override
     public RestResp<Void> saveComment(
         @Key(expr = "#{userId + '::' + bookId}") UserCommentReqDto dto) {
+        // 校验书籍是否存在
+        BookInfo bookInfo = bookInfoMapper.selectById(dto.getBookId());
+        if (bookInfo == null) {
+            return RestResp.fail(ErrorCodeEnum.BOOK_NOT_FOUND);
+        }
         // 校验用户是否已发表评论
         QueryWrapper<BookComment> queryWrapper = new QueryWrapper<>();
         queryWrapper.eq(DatabaseConsts.BookCommentTable.COLUMN_USER_ID, dto.getUserId())


### PR DESCRIPTION
- 在保存评论前校验小说是否存在  

增强代码健壮性，对小说添加评论首先应检查评论是否存在，如果添加了不存在的小说id，查询用户所有评论时调用`listComments`会导致`NullPointerException`问题。  
其实应该增强查询评论接口哪里的代码健壮性，但理论上只要评论这里没有脏数据那么查询评论就不会出错，先这样放着吧以后有时间再看看。

<img width="1160" height="751" alt="down" src="https://github.com/user-attachments/assets/b0619a2c-c47c-4288-bb5f-4642b6f3660b" />


