### PR TITLE
fix: remove hard-coded default JWT signing secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ io
 
 👉 [立即查看](https://docs.xxyopen.com/course/novel/#%E5%AE%89%E8%A3%85%E6%AD%A5%E9%AA%A4)
 
+启动前请配置部署专用的 JWT 密钥，至少使用 32 字节随机值：
+
+```bash
+export NOVEL_JWT_SECRET="$(openssl rand -base64 32)"
+```
+
 ## 联系我们
 
 👉 [立即查看](https://novel.xxyopen.com/service.htm)

--- a/src/main/java/io/github/xxyopen/novel/core/util/JwtUtils.java
+++ b/src/main/java/io/github/xxyopen/novel/core/util/JwtUtils.java
@@ -5,12 +5,14 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.WeakKeyException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
 
 /**
  * JWT 工具类
@@ -18,21 +20,29 @@ import org.springframework.stereotype.Component;
  * @author xiongxiaoyang
  * @date 2022/5/17
  */
-@ConditionalOnProperty("novel.jwt.secret")
 @Component
 @Slf4j
 public class JwtUtils {
 
-    /**
-     * 注入JWT加密密钥
-     */
-    @Value("${novel.jwt.secret}")
-    private String secret;
+    private final SecretKey secretKey;
 
     /**
      * 定义系统标识头常量
      */
     private static final String HEADER_SYSTEM_KEY = "systemKeyHeader";
+
+    public JwtUtils(@Value("${novel.jwt.secret}") String secret) {
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException(
+                "novel.jwt.secret must be configured with a deployment-specific value");
+        }
+        try {
+            this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        } catch (WeakKeyException exception) {
+            throw new IllegalStateException(
+                "novel.jwt.secret must contain at least 256 bits of key material", exception);
+        }
+    }
 
     /**
      * 根据用户ID生成JWT
@@ -45,7 +55,7 @@ public class JwtUtils {
         return Jwts.builder()
             .setHeaderParam(HEADER_SYSTEM_KEY, systemKey)
             .setSubject(uid.toString())
-            .signWith(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)))
+            .signWith(secretKey)
             .compact();
     }
 
@@ -60,7 +70,7 @@ public class JwtUtils {
         Jws<Claims> claimsJws;
         try {
             claimsJws = Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)))
+                .setSigningKey(secretKey)
                 .build()
                 .parseClaimsJws(token);
             // OK, we can trust this JWT

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -19,7 +19,7 @@
     {
       "name": "novel.jwt.secret",
       "type": "java.lang.String",
-      "description": "JWT 密钥."
+      "description": "Required deployment-specific JWT signing secret. Configure it with NOVEL_JWT_SECRET."
     },
     {
       "name": "novel.xss.enabled",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -227,7 +227,7 @@ novel:
       - http://localhost:8080
   # JWT 密钥
   jwt:
-    secret: E66559580A1ADF48CDD928516062F12E
+    secret: ${NOVEL_JWT_SECRET}
   # XSS 过滤配置
   xss:
     # 过滤开关
@@ -274,5 +274,4 @@ spring:
       host: 127.0.0.1
       port: 6379
       password:
-
 

--- a/src/test/java/io/github/xxyopen/novel/core/util/JwtUtilsTest.java
+++ b/src/test/java/io/github/xxyopen/novel/core/util/JwtUtilsTest.java
@@ -1,0 +1,29 @@
+package io.github.xxyopen.novel.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class JwtUtilsTest {
+
+    private static final String SECRET = "test-secret-with-at-least-32-bytes-1234";
+
+    @Test
+    void signsAndParsesTokenWithConfiguredSecret() {
+        JwtUtils jwtUtils = new JwtUtils(SECRET);
+        String token = jwtUtils.generateToken(1001L, "front");
+
+        assertEquals(1001L, jwtUtils.parseToken(token, "front"));
+    }
+
+    @Test
+    void rejectsMissingSecret() {
+        assertThrows(IllegalStateException.class, () -> new JwtUtils(" "));
+    }
+
+    @Test
+    void rejectsWeakSecret() {
+        assertThrows(IllegalStateException.class, () -> new JwtUtils("too-short"));
+    }
+}


### PR DESCRIPTION
## Summary

- Remove the hard-coded JWT signing secret from `application.yml`.
- Require a deployment-specific `NOVEL_JWT_SECRET` value.
- Reject missing, blank, or weak secrets during JWT utility initialization.
- Add regression tests and deployment documentation.

## Security impact

The previous configuration provided the same signing secret to every default deployment. An attacker who obtained that public value could forge valid JWTs for existing user IDs and bypass the token signature boundary.

This change removes the shared default and requires each deployment to configure its own signing secret with at least 256 bits of key material.

## Validation

- `JwtUtils` compiled successfully against the project JWT implementation.
- Valid tokens can be signed and parsed.
- Tokens with an incorrect system identifier are rejected.
- Weak secrets are rejected.
- Added JUnit regression tests for signing/parsing and invalid secrets.

The complete Maven test suite could not be run locally because the repository's large dependency graph is not fully cached in the local Maven repository.
